### PR TITLE
Fix data collator class

### DIFF
--- a/data_collator.py
+++ b/data_collator.py
@@ -1,8 +1,7 @@
 import torch
-from transformers import Wav2Vec2Processor
-
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
+from transformers import Wav2Vec2Processor
 
 @dataclass
 class DataCollatorCTCWithPadding:
@@ -10,26 +9,24 @@ class DataCollatorCTCWithPadding:
     Data collator that will dynamically pad the inputs received.
     Args:
         processor (:class:`~transformers.Wav2Vec2Processor`)
-            The processor used for proccessing the data.
-        padding (:obj:`bool`, :obj:`str` or :class:`~transformers.tokenization_utils_base.PaddingStrategy`, `optional`, defaults to :obj:`True`):
+            The processor used for processing the data.
+        padding (:obj:`bool`, :obj:`str`, defaults to :obj:`True`):
             Select a strategy to pad the returned sequences (according to the model's padding side and padding index)
             among:
-            * :obj:`True` or :obj:`'longest'`: Pad to the longest sequence in the batch (or no padding if only a single
-              sequence if provided).
-            * :obj:`'max_length'`: Pad to a maximum length specified with the argument :obj:`max_length` or to the
-              maximum acceptable input length for the model if that argument is not provided.
-            * :obj:`False` or :obj:`'do_not_pad'` (default): No padding (i.e., can output a batch with sequences of
+            * :obj:`True` or :obj:`'longest'`: Pad to the longest sequence in the batch
+            * :obj:`'max_length'`: Pad to a maximum length specified with the argument :obj:`max_length`
+            * :obj:`False` or :obj:`'do_not_pad'`: No padding (i.e., can output a batch with sequences of
               different lengths).
         max_length (:obj:`int`, `optional`):
-            Maximum length of the ``input_values`` of the returned list and optionally padding length (see above).
+            Maximum length of the ``input_values`` of the returned list and optionally padding length.
         max_length_labels (:obj:`int`, `optional`):
-            Maximum length of the ``labels`` returned list and optionally padding length (see above).
+            Maximum length of the ``labels`` returned list and optionally padding length.
         pad_to_multiple_of (:obj:`int`, `optional`):
             If set will pad the sequence to a multiple of the provided value.
-            This is especially useful to enable the use of Tensor Cores on NVIDIA hardware with compute capability >=
-            7.5 (Volta).
+            This is especially useful to enable the use of Tensor Cores on NVIDIA hardware with compute capability >= 7.5.
+        pad_to_multiple_of_labels (:obj:`int`, `optional`):
+            Same as pad_to_multiple_of but for the label sequences.
     """
-
     processor: Wav2Vec2Processor
     padding: Union[bool, str] = True
     max_length: Optional[int] = None
@@ -38,11 +35,11 @@ class DataCollatorCTCWithPadding:
     pad_to_multiple_of_labels: Optional[int] = None
 
     def __call__(self, features: List[Dict[str, Union[List[int], torch.Tensor]]]) -> Dict[str, torch.Tensor]:
-        # split inputs and labels since they have to be of different lenghts and need
+        # Split inputs and labels since they have to be of different lengths and need
         # different padding methods
         input_features = [{"input_values": feature["input_values"]} for feature in features]
-        label_features = [{"input_ids": feature["labels"]} for feature in features]
-
+        
+        # Process input features
         batch = self.processor.pad(
             input_features,
             padding=self.padding,
@@ -50,18 +47,21 @@ class DataCollatorCTCWithPadding:
             pad_to_multiple_of=self.pad_to_multiple_of,
             return_tensors="pt",
         )
-        with self.processor.as_target_processor():
-            labels_batch = self.processor.pad(
-                label_features,
-                padding=self.padding,
-                max_length=self.max_length_labels,
-                pad_to_multiple_of=self.pad_to_multiple_of_labels,
-                return_tensors="pt",
-            )
 
-        # replace padding with -100 to ignore loss correctly
+        # Handle labels separately since they're already tokenized
+        label_features = [{"input_ids": feature["labels"]} for feature in features]
+        
+        # Process labels using the tokenizer's pad function directly
+        labels_batch = self.processor.tokenizer.pad(
+            label_features,
+            padding=self.padding,
+            max_length=self.max_length_labels,
+            pad_to_multiple_of=self.pad_to_multiple_of_labels,
+            return_tensors="pt",
+        )
+
+        # Replace padding with -100 to ignore loss correctly
         labels = labels_batch["input_ids"].masked_fill(labels_batch.attention_mask.ne(1), -100)
-
         batch["labels"] = labels
 
         return batch


### PR DESCRIPTION
Data Collator class showed warnings of deprecated parameters with the latest version of Transformers library. The class was updated to use the tokenizer's pad function directly.